### PR TITLE
Fix build-ami.py.

### DIFF
--- a/modules/virtualenv/files/requirements.txt
+++ b/modules/virtualenv/files/requirements.txt
@@ -3,7 +3,7 @@ argparse==1.2.1
 boto==2.8.0
 boto-rsync==0.8.1
 distribute==0.6.34
-psutil==0.6.1
+psutil==1.2.1
 psycopg2==2.4.6
 pygtail==0.2.1
 python-binary-memcached==0.18

--- a/modules/virtualenv/manifests/init.pp
+++ b/modules/virtualenv/manifests/init.pp
@@ -12,10 +12,16 @@ class virtualenv {
         require    => Package['python-setuptools'],
     }
     
+    exec {"upgrade-setuptools":
+        path        => '/usr/local/bin',
+        command     => "pip install --upgrade --no-use-wheel setuptools",
+        require     => Exec['easy_install pip'],
+    }
+
     package {'virtualenv':
         ensure     => present,
         provider   => pip,
-        require    => Exec['easy_install pip'],
+        require    => Exec['upgrade-setuptools'],
     }
 
     exec {"install-virtualenv":


### PR DESCRIPTION
Out-of-date setuptools and psutil requirement
resulted in failing pip install command.

Fixes #12.
