### PR TITLE
Added packages needed by oab-java

### DIFF
--- a/modules/apt/manifests/init.pp
+++ b/modules/apt/manifests/init.pp
@@ -21,7 +21,11 @@ class apt {
         require => Exec['apt-update'],
     }
 
-    $packages = ['rsync', 'screen', 'zip', 'git', 'libpq-dev', 'tree']
+    $packages = [
+        'rsync', 'screen', 'zip', 'git', 'libpq-dev', 'tree',
+        'devscripts', 'debhelper', 'libasound2', 'unixodbc',
+        'libxi6', 'libxt6', 'libxtst6', 'libxrender1', 'rng-tools'
+    ]
     package {$packages:
         ensure  => present,
         require => Exec['apt-upgrade'],


### PR DESCRIPTION
I ran into a problem where the AMI ended up being bad because java was never built. The error is here: https://gist.github.com/jeremyharris/0fe6d53c108028ed8f66#file-gistfile1-txt-L57

I tried to inspect the oab-java log while puppet was installing it but for some reason it never generated a log. Then I booted up the bad AMI, ran `oab-java.sh` manually and dealt with the errors one at a time. It turned out it wouldn't install because it was missing certain packages here and there, which I added.

After adding these packages and running it again, the AMI built correctly and ran successfully using Minecloud.

P.S. Thanks for this project - it saved me a ton of time and effort and turned out better than what I was probably going to end up with :)
